### PR TITLE
RecaptchaV3 no catched exception

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -187,7 +187,6 @@ return static function (ContainerConfigurator $container): void {
             ->arg('$secretKey', param('leapt_core.recaptcha.private_key'))
             ->arg('$scoreThreshold', param('leapt_core.recaptcha.score_threshold'))
             ->arg('$requestStack', service('request_stack'))
-            ->arg('$logger', service('logger'))
             ->tag('validator.constraint_validator', ['alias' => 'leapt_core.recaptcha_v3'])
     ;
 };

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -64,7 +64,7 @@ error message should be displayed in debug mode when validating.
     public $recaptcha;
 
     // Or if you need technical details about why the captcha is invalid:
-    #[LeaptAssert\RecaptchaV3(message: LeaptAssert\RecaptchaV3::$technicalMessage)]
+    #[LeaptAssert\RecaptchaV3(message: LeaptAssert\RecaptchaV3::TECHNICAL_MESSAGE)]
     public $recaptcha;
     ```
 

--- a/src/Validator/Constraints/RecaptchaV3.php
+++ b/src/Validator/Constraints/RecaptchaV3.php
@@ -7,9 +7,9 @@ namespace Leapt\CoreBundle\Validator\Constraints;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 class RecaptchaV3 extends Recaptcha
 {
-    public string $message = 'The submitted captcha is invalid.';
+    public const TECHNICAL_MESSAGE = 'The submitted captcha is invalid. Error codes: {{ errorCodes }}. Score: {{ score }}.';
 
-    public static string $technicalMessage = 'The submitted captcha is invalid. Error codes: {{ errorCodes }}. Score: {{ score }}.';
+    public string $message = 'The submitted captcha is invalid.';
 
     public function validatedBy(): string
     {


### PR DESCRIPTION
- Do not catch the exception when the secret is empty in RecaptchaV3Validator.
- Use const instead of static for the technical message in RecaptchaV3.